### PR TITLE
Build OpenBabel as separate module like in actual Flatpak

### DIFF
--- a/flatpak/org.openchemistry.Avogadro2.yaml
+++ b/flatpak/org.openchemistry.Avogadro2.yaml
@@ -34,6 +34,25 @@ modules:
         # Would rather use 4d6cb08189cf7336821f04090b612baa2ca6a90d (same commit as openSUSE
         # Tumbleweed) as known to be good, but older commits like that don't seem to compile
         commit: 7c73dd7de7c4f14379b781418c6e947ad464c818
+        
+  - name: openbabel
+    buildsystem: cmake-ninja
+    builddir: true
+    config-opts:
+      # Match the way Avogadro builds Open Babel
+      - -DCMAKE_BUILD_TYPE=Release
+      - -DENABLE_TESTS=OFF
+      - -DBUILD_GUI=OFF
+      - -DOPTIMIZE_NATIVE=OFF
+      - -DOB_USE_PREBUILT_BINARIES=OFF
+      - -DENABLE_VERSIONED_FORMATS=OFF
+      - -DWITH_JSON=ON
+      - -DWITH_COORDGEN=OFF
+      - -DWITH_MAEPARSER=OFF
+    sources:
+      - type: git
+        url: https://github.com/openbabel/openbabel.git
+        commit: 32cf131444c1555c749b356dab44fb9fe275271f
 
   - name: avogadro2
     buildsystem: cmake-ninja
@@ -47,6 +66,7 @@ modules:
       - -DBUILD_MOLEQUEUE=OFF
       - -DQT_VERSION=6
       - -DDOWNLOAD_TO_SOURCE_DIR=ON
+      - -DUSE_SYSTEM_OPENBABEL=ON
     sources:
       # Avogadro stuff all already collected together as part of GitHub Actions
       # This means that if using this to build the Flatpak locally, the openchemistry repo and
@@ -58,8 +78,8 @@ modules:
       # Now fetch third-party stuff where the source is expected in `openchemistry/thirdparty`
       # VTK
       - type: archive
-        url: https://www.vtk.org/files/release/9.3/VTK-9.3.0.tar.gz
-        sha256: fdc7b9295225b34e4fdddc49cd06e66e94260cb00efee456e0f66568c9681be9
+        url: https://github.com/Kitware/VTK/archive/4f02ae83179c6a1542ac3c335c73dea976578c63.tar.gz
+        sha256: 2d2da63dc660016628fc41c3a201e24d49a7e67b0d5d6fbbe655fb23f5099929
         dest: thirdparty/VTK
       
       # Other third-party sources would normally be downloaded by Avogadro build on the fly


### PR DESCRIPTION
Developer Certificate of Origin
Version 1.1

Copyright (C) 2004, 2006 The Linux Foundation and its contributors.
1 Letterman Drive
Suite D4700
San Francisco, CA, 94129

Everyone is permitted to copy and distribute verbatim copies of this
license document, but changing it is not allowed.


Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
